### PR TITLE
update: 処理の始めにファイルのエンコーディングがEUC-JPか確認する #8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "clap"
 version = "3.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,6 +68,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -198,6 +213,7 @@ name = "unitil"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "encoding_rs",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "3.2.12", features = ["derive"] }
+encoding_rs = "0.8.31"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,19 @@
 use clap::Parser;
 use std::fs;
 
-fn main() -> std::io::Result<()> {
+fn main() {
     let args = Args::parse();
 
     let contents = fs::read(&args.file).expect("Something went wrong reading the file");
+
+    // ファイルのエンコーディングチェック(EUC-JP)
+    let (_, _, is_handring_error) = encoding_rs::EUC_JP.decode(&contents);
+
+    if is_handring_error {
+        eprintln!("Error decoding contents");
+        eprintln!("Only 'EUC-JP' is supported");
+        std::process::exit(1);
+    }
 
     if args.count {
         let count = count_tilde(contents);
@@ -12,10 +21,8 @@ fn main() -> std::io::Result<()> {
         println!("Fullwidth Tilde (0x8FA2B7) : {}", count.1);
     } else {
         let new_contents = unify_tilde(contents);
-        fs::write(&args.file, new_contents)?;
+        fs::write(&args.file, new_contents).expect("Something went wrong writing the file");
     }
-
-    Ok(())
 }
 
 #[derive(Debug, Parser)]


### PR DESCRIPTION
- EUC-JPの場合 -> 処理を継続
- EUC-JP以外の場合 -> 処理を中止(エラー)